### PR TITLE
Small tweaks to Authorizations API curl call

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ You can generate an OAuth token from via the
 with cURL:
 
 ```bash
-curl -X POST -i -d "{ \"scopes\": [\"repo\"] }" \
-https://<github_login>:<github_password>@api.github.com/authorizations
+curl -u <github_login> -i -d "{ \"scopes\": [\"repo\"] }" \
+https://api.github.com/authorizations
 ```
 
 Add as the very last middleware in your production `Rack` stack.


### PR DESCRIPTION
Just a couple of small things:
- Just use `-u <github_login>`, curl will prompt for password, keeps it out of shell history.
- `-d` will do `POST` 
