### PR TITLE
Keep existing labels on re-opened issues

### DIFF
--- a/lib/party_foul/exception_handler.rb
+++ b/lib/party_foul/exception_handler.rb
@@ -58,7 +58,7 @@ class PartyFoul::ExceptionHandler
       params = {body: rendered_issue.update_body(issue['body']), state: 'open'}
 
       if issue['state'] == 'closed'
-        params[:labels] = ['bug', 'regression']
+        params[:labels] = (['bug', 'regression'] + issue['labels']).uniq
       end
 
       self.sha = PartyFoul.github.git_data.references.get(PartyFoul.owner, PartyFoul.repo, "heads/#{PartyFoul.branch}").object.sha

--- a/test/party_foul/exception_handler_test.rb
+++ b/test/party_foul/exception_handler_test.rb
@@ -52,8 +52,8 @@ describe 'Party Foul Exception Handler' do
     context 'and closed' do
       it 'will update the count on the body and re-open the issue' do
         PartyFoul.github.search.stubs(:issues).with(owner: 'test_owner', repo: 'test_repo', keyword: 'test_fingerprint', state: 'open').returns(Hashie::Mash.new(issues: []))
-        PartyFoul.github.search.stubs(:issues).with(owner: 'test_owner', repo: 'test_repo', keyword: 'test_fingerprint', state: 'closed').returns(Hashie::Mash.new(issues: [{title: 'Test Title', body: 'Test Body', state: 'closed', number: 1}]))
-        PartyFoul.github.issues.expects(:edit).with('test_owner', 'test_repo', 1, body: 'New Body', state: 'open', labels: ['bug', 'regression'])
+        PartyFoul.github.search.stubs(:issues).with(owner: 'test_owner', repo: 'test_repo', keyword: 'test_fingerprint', state: 'closed').returns(Hashie::Mash.new(issues: [{title: 'Test Title', body: 'Test Body', state: 'closed', number: 1, labels: ['staging']}]))
+        PartyFoul.github.issues.expects(:edit).with('test_owner', 'test_repo', 1, body: 'New Body', state: 'open', labels: ['bug', 'regression', 'staging'])
         PartyFoul.github.issues.comments.expects(:create).with('test_owner', 'test_repo', 1, body: 'Test Comment')
         PartyFoul.github.git_data.references.expects(:get).with('test_owner', 'test_repo', 'heads/deploy').returns(Hashie::Mash.new(object: Hashie::Mash.new(sha: 'abcdefg1234567890')))
         PartyFoul::ExceptionHandler.new(nil, {}).run


### PR DESCRIPTION
GitHub will replace the labels on an existing issue when updated, this will keep any labeling done after the issue was created even when it is re-opened.
