### PR TITLE
Shortcoming in additional labels Proc handling

### DIFF
--- a/lib/party_foul/issue_renderers/base.rb
+++ b/lib/party_foul/issue_renderers/base.rb
@@ -132,7 +132,7 @@ BODY
   # @return [Array]
   def labels
     if PartyFoul.additional_labels.respond_to? :call
-      PartyFoul.additional_labels.call(self.exception, self.env)
+      PartyFoul.additional_labels.call(self.exception, self.env) || []
     else
       PartyFoul.additional_labels || []
     end


### PR DESCRIPTION
Handle the case where the additional labels Proc does not return anything.  It seems unnecessary to force the proc to return an array in every case, only force it to return an array of labels when they match their criteria, and handle when the Proc returns nil.
