### PR TITLE
Escape HTML Entities

### DIFF
--- a/lib/party_foul/issue_renderers/base.rb
+++ b/lib/party_foul/issue_renderers/base.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 class PartyFoul::IssueRenderers::Base
   attr_accessor :exception, :env, :sha
 
@@ -122,6 +124,8 @@ BODY
       key, value = row
       if row[1].kind_of?(Hash)
         value = build_table_from_hash(row[1])
+      else
+        value = CGI.escapeHTML(value.to_s)
       end
       rows << "<tr><th>#{key}</th><td>#{value}</td></tr>"
     end

--- a/test/party_foul/issue_renderers/base_test.rb
+++ b/test/party_foul/issue_renderers/base_test.rb
@@ -79,6 +79,13 @@ Fingerprint: `abcdefg1234567890`
       expected = '<table><tr><th>Value 1</th><td>abc</td></tr><tr><th>Value 2</th><td><table><tr><th>Value A</th><td>123</td></tr><tr><th>Value B</th><td>456</td></tr></table></td></tr></table>'
       rendered_issue.build_table_from_hash(hash).must_equal expected
     end
+
+    it 'escapes HTML entities' do
+      rendered_issue = PartyFoul::IssueRenderers::Base.new(nil, nil)
+      hash = { 'Value 1' => 'Error in #<Foo>' }
+      expected = '<table><tr><th>Value 1</th><td>Error in #&lt;Foo&gt;</td></tr></table>'
+      rendered_issue.build_table_from_hash(hash).must_equal expected
+    end
   end
 
   describe '#fingerprint' do


### PR DESCRIPTION
An error similar to this:

```
UsersController# (NameError) "undefined local variable or method `foo' for #<UsersController:0x0000000d2f4c18>"
```

Is currently displaying like this, because the brackets around `<UsersController...>` are not being escaped.

<table><tr><th>Exception</th><td>undefined local variable or method `foo' for #<UsersController:0x0000000d2f4c18></td></tr><tr><th>Last Occurrence</th><td>February 14, 2013 11:54:30 -0800</td></tr><tr><th>Count</th><td>1</td></tr></table>


With this pull request, it will now display as:

<table><tr><th>Exception</th><td>undefined local variable or method `foo' for #&lt;UsersController:0x0000000d2f4c18&gt;</td></tr><tr><th>Last Occurrence</th><td>February 14, 2013 11:54:30 -0800</td></tr><tr><th>Count</th><td>1</td></tr></table>


I'm just using Ruby's basic built in `CGI.escapeHTML`
