### PR TITLE
Memoize occurred_at for consistent times

### DIFF
--- a/lib/party_foul/issue_renderers/base.rb
+++ b/lib/party_foul/issue_renderers/base.rb
@@ -89,7 +89,7 @@ BODY
   #
   # @return [String]
   def occurred_at
-    Time.now.strftime('%B %d, %Y %H:%M:%S %z')
+    @occurred_at ||= Time.now.strftime('%B %d, %Y %H:%M:%S %z')
   end
 
   # The hash used for building the table in issue body

--- a/test/party_foul/issue_renderers/base_test.rb
+++ b/test/party_foul/issue_renderers/base_test.rb
@@ -95,4 +95,13 @@ Fingerprint: `abcdefg1234567890`
       rendered_issue.fingerprint.must_equal Digest::SHA1.hexdigest(rendered_issue.title)
     end
   end
+
+  describe '#occurred_at' do
+    it 'memoizes the time' do
+      rendered_issue = PartyFoul::IssueRenderers::Base.new(nil, nil)
+      expected = rendered_issue.occurred_at
+      Time.stubs(:now).returns(Time.new(1970, 1, 1, 0, 0, 1, '-05:00'))
+      rendered_issue.occurred_at.must_equal expected
+    end
+  end
 end


### PR DESCRIPTION
Sometimes there's a slight delay between the body being generated and the issue's comment being posted, resulting in the issue's and the comment's "Occurred At" values being a couple seconds apart.

This update memoizes the current time when `occurred_at` is first called.
