### PR TITLE
Tracking errors outside of an HTTP request does not work as expected (or as documented)

### DIFF
--- a/lib/party_foul/rackless_exception_handler.rb
+++ b/lib/party_foul/rackless_exception_handler.rb
@@ -5,7 +5,7 @@ class PartyFoul::RacklessExceptionHandler < PartyFoul::ExceptionHandler
   #
   # @param [Exception, Hash]
   def self.handle(exception, env)
-    self.new(exception, clean_env(env)).run
+    self.new(exception, env).run
   end
 
   # Uses the Rackless IssueRenderer for a rackless environment

--- a/test/party_foul/rackless_exception_handler_test.rb
+++ b/test/party_foul/rackless_exception_handler_test.rb
@@ -14,6 +14,14 @@ describe 'Party Foul Rackless Exception Handler' do
       PartyFoul::RacklessExceptionHandler.any_instance.expects(:run)
       PartyFoul::RacklessExceptionHandler.handle(nil, {})
     end
+
+    it 'should pass parameters required by the renderer to the initializer' do
+      params = {:class => Object, :method => :to_s, :params => {:one => "One", :two => "Two"}}
+      expected_exception_handler = PartyFoul::RacklessExceptionHandler.new(nil, params)
+      expected_exception_handler.expects(:run)
+      PartyFoul::RacklessExceptionHandler.expects(:new).with(nil, params).returns(expected_exception_handler)
+      PartyFoul::RacklessExceptionHandler.handle(nil, params)      
+    end
   end
 
   describe '#initialize' do


### PR DESCRIPTION
While trying to instrument some background processing tasks with the RacklessExceptionHandler, I noticed that it doesn't pass the expected keys to the rackless issue renderer. 

For example, when I invoke the RacklessExceptionHandler like this

```
PartyFoul::RacklessExceptionHandler.handle(e, {class: Connection, method: "somemethod", params: {:user => "User", :zipcode => "90210"}})
```

It creates a github issue that looks like this 

![image](https://f.cloud.github.com/assets/22246/178172/d7eec3ea-7bad-11e2-801a-9bad888dbdf8.png)

with the following parameters

![image](https://f.cloud.github.com/assets/22246/178176/e87095b8-7bad-11e2-912c-c9940e2d7289.png)

This is because the rackless exception handler was trying to sanitize the parameters, which makes sense in the context of a web request, but doesn't (I don't think) outside the context of one.
