### PR TITLE
Improve 'io-console' loading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ gemspec
 unless ENV['CI'] || RUBY_PLATFORM =~ /java/ || RUBY_VERSION >= '2.0.0'
   gem 'debugger'
 end
+
+unless RUBY_PLATFORM =~ /java/ || RUBY_VERSION >= '2.0.0'
+  gem 'io-console', '~> 0.3.0'
+end

--- a/lib/generators/party_foul/install_generator.rb
+++ b/lib/generators/party_foul/install_generator.rb
@@ -1,6 +1,11 @@
 require 'rails/generators'
-require 'io/console'
 require 'net/http'
+
+begin
+  require 'io/console'
+rescue LoadError => e
+  raise LoadError, "Error: io-console is not installed. Please add `gem 'io-console', '~> 0.3.0'` to your bundle before running the generator"
+end
 
 module PartyFoul
   class InstallGenerator < Rails::Generators::Base

--- a/party_foul.gemspec
+++ b/party_foul.gemspec
@@ -15,9 +15,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'github_api', '~> 0.8.8'
-  unless RUBY_PLATFORM =~ /java/ || RUBY_VERSION >= '2.0.0'
-    s.add_dependency 'io-console', '~> 0.3.0'
-  end
 
   s.add_development_dependency 'actionpack', '~> 3.2.11'
   s.add_development_dependency 'activesupport', '~> 3.2.11'


### PR DESCRIPTION
**tl;dr party_foul 1.1.1 is broken on 1.9.2**

Since the gemspec is evaluated at **build time** and not runtime like Gemfile, ad0435f08ed72030fa58353eb3d154224960747c means that whether the gem depends on `io-console` is determined by which platform you build it on.

This is a common problem when trying to specify different dependencies for different platforms, and the gemspec doesn't really support it.

IMO, it'd be nice to get rid of the io-console dependency entirely, but failing that, this PR uses a similar approach to gems with the same problem, e.g. [comma](https://github.com/crafterm/comma/blob/78bceb282ff1234a9ca31fc586f8c75edf3cf34b/lib/comma.rb#L2-L14), [zeus](https://github.com/burke/zeus/commit/1dd4e81)
