### PR TITLE
Add ruby 1.9 requirement

### DIFF
--- a/party_foul.gemspec
+++ b/party_foul.gemspec
@@ -11,6 +11,8 @@ Gem::Specification.new do |s|
   s.summary     = 'Auto-submit Rails exceptions as new isues on GitHub'
   s.description = 'Auto-submit Rails exceptions as new isues on GitHub'
 
+  s.required_ruby_version = '>= 1.9'
+
   s.files = Dir['{app,config,db,lib}/**/*'] + ['Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 


### PR DESCRIPTION
Saves some hassle when trying to install for legacy projects.
