### PR TITLE
Enable PartyFoul::IssueRenderers::Rails works without session

### DIFF
--- a/lib/party_foul/issue_renderers/rails.rb
+++ b/lib/party_foul/issue_renderers/rails.rb
@@ -12,7 +12,7 @@ class PartyFoul::IssueRenderers::Rails < PartyFoul::IssueRenderers::Rack
   # @return [Hash]
   def session
     parameter_filter = ActionDispatch::Http::ParameterFilter.new(env['action_dispatch.parameter_filter'])
-    parameter_filter.filter(env['rack.session'])
+    parameter_filter.filter(env['rack.session'] || { } )
   end
 
   private

--- a/test/party_foul/issue_renderers/rails_test.rb
+++ b/test/party_foul/issue_renderers/rails_test.rb
@@ -13,14 +13,27 @@ describe 'Rails Issue Renderer' do
   end
 
   describe '#session' do
+    let(:params) { {'action_dispatch.parameter_filter' => ['password'], 'rack.session' => { 'status' => 'ok', 'password' => 'test' }, 'QUERY_STRING' => { 'status' => 'fail' } } }
+    
     before do
-      @rendered_issue = PartyFoul::IssueRenderers::Rails.new(nil, {'action_dispatch.parameter_filter' => ['password'], 'rack.session' => { 'status' => 'ok', 'password' => 'test' }, 'QUERY_STRING' => { 'status' => 'fail' } })
+      @rendered_issue = PartyFoul::IssueRenderers::Rails.new(nil, params)
     end
 
     it 'returns ok' do
       @rendered_issue.session['status'].must_equal 'ok'
       @rendered_issue.session['password'].must_equal '[FILTERED]'
     end
+
+    context "without session" do
+     
+      let(:params) { {'action_dispatch.parameter_filter' => ['password'], 'QUERY_STRING' => { 'status' => 'fail' } } }
+
+      it 'returns empty hash' do
+        @rendered_issue.session.must_be_empty
+      end
+    end
+
+
   end
 
   describe '#raw_title' do


### PR DESCRIPTION
Hey Guys,

 Enable use Rails Renderers without session 'rack.session'.

 My Api do not have any session and the party_foul raise NoMethodError: undefined method `each' for nil:NilClass when try to call PartyFoul::IssueRenderers::Rails#session

Thanks
