### PR TITLE
Version Bump

### DIFF
--- a/lib/party_foul/version.rb
+++ b/lib/party_foul/version.rb
@@ -1,3 +1,3 @@
 module PartyFoul
-  VERSION = '1.2.2'
+  VERSION = '1.2.3'
 end


### PR DESCRIPTION
 Bump the Version to 1.2.3.

gem install still download 1.2.2 without improvements.

```
$ gem install party_foul
Fetching: party_foul-1.2.2.gem (100%)
Successfully installed party_foul-1.2.2
1 gem installed
```

Thanks guys.
