### PR TITLE
Prevent crash when submitting large comments

### DIFF
--- a/lib/party_foul.rb
+++ b/lib/party_foul.rb
@@ -3,7 +3,7 @@ require 'octokit'
 module PartyFoul
   class << self
     attr_accessor :github, :oauth_token, :owner, :repo, :additional_labels, :comment_limit, :title_prefix
-    attr_writer :branch, :web_url, :api_endpoint, :processor, :blacklisted_exceptions
+    attr_writer :branch, :web_url, :api_endpoint, :processor, :blacklisted_exceptions, :max_comment_size
   end
 
   # The git branch that is used for linking in the stack trace
@@ -66,6 +66,14 @@ module PartyFoul
   # @return [String]
   def self.repo_url
     "#{web_url}/#{repo_path}"
+  end
+
+  # The maximum size of a commit that can be submitted to GitHub.
+  # Comments larger than this will be truncated.
+  #
+  # @return [Integer]
+  def self.max_comment_size
+    @max_comment_size ||= 65_535
   end
 
   # The configure block for PartyFoul. Use to initialize settings

--- a/lib/party_foul/issue_renderers/base.rb
+++ b/lib/party_foul/issue_renderers/base.rb
@@ -44,7 +44,9 @@ BODY
   # Customize by overriding {#comment_options}
   #
   def comment
-    build_table_from_hash(comment_options)
+    html = build_table_from_hash(comment_options)
+    html = truncate_comment while html.size > PartyFoul.max_comment_size
+    html
   end
 
   # Compiles the stack trace for use in the issue body. Lines in the
@@ -183,5 +185,12 @@ BODY
     else
       line.sub(app_root, '[app]...')
     end
+  end
+
+  def truncate_comment
+    @sorted_comment_options ||= comment_options.sort_by { |_, v| v.size }
+    key_of_largest = @sorted_comment_options.pop[0]
+    comment_options[key_of_largest] = '[truncated]' if key_of_largest
+    build_table_from_hash(comment_options)
   end
 end

--- a/test/party_foul/issue_renderers/base_test.rb
+++ b/test/party_foul/issue_renderers/base_test.rb
@@ -207,4 +207,40 @@ Fingerprint: `abcdefg1234567890`
       end
     end
   end
+
+  describe '#comment' do
+    before do
+      @rendered_issue = PartyFoul::IssueRenderers::Base.new(nil, nil)
+    end
+
+    it 'formats comment options as a table' do
+      @rendered_issue.stubs(:comment_options).returns({'Test Key' => 'Test Value'})
+      expected_comment = "<table><tr><th>Test Key</th><td>Test Value</td></tr></table>"
+      @rendered_issue.comment.must_equal expected_comment
+    end
+
+    context 'with a huge table' do
+      before do
+        @rendered_issue.stubs(:comment_options).returns({
+          'Test Key'         => 'Test Value',
+          'Big Key'          => 'x' * 66_000,
+          'After Key'        => 'Should be included',
+          'Another Big Key'  => 'z' * 66_000,
+        })
+      end
+
+      it 'truncates the comment' do
+        expected_comment = <<-COMMENT.delete("\n")
+<table>
+<tr><th>Test Key</th><td>Test Value</td></tr>
+<tr><th>Big Key</th><td>[truncated]</td></tr>
+<tr><th>After Key</th><td>Should be included</td></tr>
+<tr><th>Another Big Key</th><td>[truncated]</td></tr>
+</table>
+        COMMENT
+        @rendered_issue.comment.must_equal expected_comment
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Protects against:

> POST https://api.github.com/repos/xxx/xxx/issues/999/comments?access_token=xxxx: 422 body is too long (maximum is 65535 characters)

This occurs, for example, when `params` contains too much data.
