### PR TITLE
set octokit version dependency < 2.0.0

### DIFF
--- a/party_foul.gemspec
+++ b/party_foul.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*'] + ['Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'octokit'
+  s.add_dependency 'octokit', '< 2.0.0'
 
   s.add_development_dependency 'actionpack', '~> 4.0'
   s.add_development_dependency 'activesupport', '~> 4.0'


### PR DESCRIPTION
octokit 2.0.0 introduces breaking API changes. The main thing that affects party_foul is that it drops Hashie::Mash in favor of Sawyer::Resource.

Until party_foul supports octokit 2.0.0, it needs this gem dependency.
