### PR TITLE
Use Rack Request

### DIFF
--- a/lib/party_foul/issue_renderers/rack.rb
+++ b/lib/party_foul/issue_renderers/rack.rb
@@ -38,7 +38,12 @@ class PartyFoul::IssueRenderers::Rack < PartyFoul::IssueRenderers::Base
   #
   # @return [Hash]
   def http_headers
-    { Version: env['HTTP_VERSION'], 'User Agent' => env['HTTP_USER_AGENT'], 'Accept Encoding' => env['HTTP_ACCEPT_ENCODING'], Accept: env['HTTP_ACCEPT'] }
+    {
+      Version: env['HTTP_VERSION'], 
+      'User Agent' => request.user_agent, 
+      'Accept Encoding' => env['HTTP_ACCEPT_ENCODING'], 
+      Accept: env['HTTP_ACCEPT'], 
+    }
   end
 
   private

--- a/test/party_foul/issue_renderers/rack_test.rb
+++ b/test/party_foul/issue_renderers/rack_test.rb
@@ -56,6 +56,23 @@ describe 'Rack Issue Renderer' do
       issue_renderer = PartyFoul::IssueRenderers::Rack.new(nil, { 'rack.session' => 'abc:123' })
       issue_renderer.session.must_equal 'abc:123'
     end    
-  end  
+  end
+  
+  describe '#http_headers' do
+    it 'returns http headers' do
+      issue_renderer = PartyFoul::IssueRenderers::Rack.new(nil, 
+        { 
+          'HTTP_VERSION' => 'version',
+          'HTTP_USER_AGENT' => 'user agent',
+          'HTTP_ACCEPT_ENCODING' => 'accept encoding',
+          'HTTP_ACCEPT' => 'accept' 
+        })
+        
+      issue_renderer.http_headers[:Version].must_equal 'version'
+      issue_renderer.http_headers['User Agent'].must_equal 'user agent'
+      issue_renderer.http_headers['Accept Encoding'].must_equal 'accept encoding'
+      issue_renderer.http_headers[:Accept].must_equal 'accept'
+    end    
+  end
       
 end


### PR DESCRIPTION
I noticed that the IP address is incorrect for requests that use a load balancer. We can use `Rack::Request` to take a better guess at the actual IP address.

In particular, see the `ip` method here: https://github.com/rack/rack/blob/master/lib/rack/request.rb#L354

In general, we can use `Rack::Request` to extract the url, ip_address, etc from the `env`. I will start working on it.
