### PR TITLE
install: undefined method `new' for Octokit:Module (NoMethodError)

### DIFF
--- a/lib/generators/party_foul/install_generator.rb
+++ b/lib/generators/party_foul/install_generator.rb
@@ -14,7 +14,7 @@ module PartyFoul
       @web_url      = ask_with_default 'Web URL:', 'https://github.com'
 
       begin
-        octokit      = Octokit.new :login => login, :password => password, :api_endpoint => @api_endpoint
+        octokit      = Octokit::Client.new :login => login, :password => password, :api_endpoint => @api_endpoint
         @oauth_token = octokit.create_authorization(scopes: ['repo'], note: "PartyFoul #{@owner}/#{@repo}", note_url: "#{@web_url}/#{@owner}/#{@repo}").token
         template 'party_foul.rb', 'config/initializers/party_foul.rb'
       rescue Octokit::Unauthorized

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -9,9 +9,9 @@ class PartyFoul::GeneratorTest < Rails::Generators::TestCase
   test 'it copies the initializer' do
     owner = 'test_owner'
     repo  = 'test_repo'
-    octokit = mock('Octokit')
+    octokit = mock('Octokit::Client')
     octokit.expects(:create_authorization).with(scopes: ['repo'], note: 'PartyFoul test_owner/test_repo', note_url: 'http://example.com/test_owner/test_repo').returns(sawyer_resource({token: 'test_token'}))
-    Octokit.stubs(:new).with(:login => 'test_login', :password => 'test_password', :api_endpoint => 'http://api.example.com').returns(octokit)
+    Octokit::Client.stubs(:new).with(:login => 'test_login', :password => 'test_password', :api_endpoint => 'http://api.example.com').returns(octokit)
     $stdin.stubs(:gets).returns('test_login').then.returns('test_password').then.returns(owner).then.returns(repo).then.returns('http://api.example.com').then.returns('http://example.com').then.returns('')
     run_generator
 


### PR DESCRIPTION
Trying to run `rails g party_foul:install` on a new project failed with the following error after accepting my credentials and repo details:

```
...octokit-2.3.1/lib/octokit.rb:26:in `method_missing': undefined method `new' for Octokit:Module (NoMethodError)
    from party_foul-1.4.0/lib/generators/party_foul/install_generator.rb:17:in `create_initializer_file'
```

Looks like you made a typo when switching to Octokit. This pull fixes it. Thanks!
