### PR TITLE
Fixes #82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.5.1
+ 
+ * Uses `env['action_dispatch.request.parameters']` instead of
+   `path_parameters` in rails renderer to fix missing params issue
+   ([Bug #82](https://github.com/dockyard/party_foul/issues/82)) - Dan McClain
+
 ## 1.5.0
 
  * Uses `Time.current` in `PartyFoul::IssueRenderer::Rails` to use the

--- a/lib/party_foul/issue_renderers/rails.rb
+++ b/lib/party_foul/issue_renderers/rails.rb
@@ -4,7 +4,7 @@ class PartyFoul::IssueRenderers::Rails < PartyFoul::IssueRenderers::Rack
   # @return [Hash]
   def params
     parameter_filter = ActionDispatch::Http::ParameterFilter.new(env["action_dispatch.parameter_filter"])
-    parameter_filter.filter(env['action_dispatch.request.path_parameters'])
+    parameter_filter.filter(env['action_dispatch.request.parameters'])
   end
 
   # Rails session hash. Filtered parms are respected.
@@ -30,6 +30,6 @@ class PartyFoul::IssueRenderers::Rails < PartyFoul::IssueRenderers::Rack
   end
 
   def raw_title
-    %{#{env['action_controller.instance'].class}##{env['action_dispatch.request.path_parameters']['action']} (#{exception.class}) "#{exception.message}"}
+    %{#{env['action_controller.instance'].class}##{env['action_dispatch.request.parameters']['action']} (#{exception.class}) "#{exception.message}"}
   end
 end

--- a/test/party_foul/issue_renderers/rails_test.rb
+++ b/test/party_foul/issue_renderers/rails_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe 'Rails Issue Renderer' do
   describe '#params' do
     before do
-      @rendered_issue = PartyFoul::IssueRenderers::Rails.new(nil, {'action_dispatch.parameter_filter' => ['password'], 'action_dispatch.request.path_parameters' => { 'status' => 'ok', 'password' => 'test' }, 'QUERY_STRING' => { 'status' => 'fail' } })
+      @rendered_issue = PartyFoul::IssueRenderers::Rails.new(nil, {'action_dispatch.parameter_filter' => ['password'], 'action_dispatch.request.parameters' => { 'status' => 'ok', 'password' => 'test' }, 'QUERY_STRING' => { 'status' => 'fail' } })
     end
 
     it 'returns ok' do
@@ -53,7 +53,7 @@ describe 'Rails Issue Renderer' do
       controller_instance = mock('Controller')
       controller_instance.stubs(:class).returns('LandingController')
       env = {
-        'action_dispatch.request.path_parameters' => { 'controller' => 'landing', 'action' => 'index' },
+        'action_dispatch.request.parameters' => { 'controller' => 'landing', 'action' => 'index' },
         'action_controller.instance' => controller_instance
       }
       @rendered_issue = PartyFoul::IssueRenderers::Rails.new(@exception, env)


### PR DESCRIPTION
Uses `env['action_dispatch.request.parameters']` instead of
`env['action_dispatch.request.path_parameters']`
