### PR TITLE
Use proper repo/state querying for Github v3 API

### DIFF
--- a/lib/party_foul/exception_handler.rb
+++ b/lib/party_foul/exception_handler.rb
@@ -91,6 +91,6 @@ class PartyFoul::ExceptionHandler
   end
 
   def find_first_issue(state)
-    PartyFoul.github.search_issues(fingerprint, repo: PartyFoul.repo_path, state: state).first
+    PartyFoul.github.search_issues("#{fingerprint} repo:#{PartyFoul.repo_path} state:#{state}").items.first
   end
 end

--- a/test/party_foul/exception_handler_test.rb
+++ b/test/party_foul/exception_handler_test.rb
@@ -17,8 +17,8 @@ describe 'Party Foul Exception Handler' do
     it 'will open a new error on GitHub' do
       PartyFoul::IssueRenderers::Rails.any_instance.stubs(:body).returns('Test Body')
       PartyFoul::IssueRenderers::Rails.any_instance.stubs(:comment).returns('Test Comment')
-      PartyFoul.github.expects(:search_issues).with('test_fingerprint', repo: 'test_owner/test_repo', state: 'open').returns([])
-      PartyFoul.github.expects(:search_issues).with('test_fingerprint', repo: 'test_owner/test_repo', state: 'closed').returns([])
+      PartyFoul.github.expects(:search_issues).with('test_fingerprint repo:test_owner/test_repo state:open').returns(no_search_results)
+      PartyFoul.github.expects(:search_issues).with('test_fingerprint repo:test_owner/test_repo state:closed').returns(no_search_results)
       PartyFoul.github.expects(:create_issue).with('test_owner/test_repo', 'Test Title', 'Test Body', labels: ['bug']).returns( {number: 1} )
       PartyFoul.github.expects(:references).with('test_owner/test_repo', 'heads/deploy').returns( sawyer_resource({object: {sha: 'abcdefg1234567890'}}) )
       PartyFoul.github.expects(:add_comment).with('test_owner/test_repo', 1, 'Test Comment')
@@ -37,8 +37,8 @@ describe 'Party Foul Exception Handler' do
       it 'will open a new error on GitHub with the additional labels' do
         PartyFoul::IssueRenderers::Rails.any_instance.stubs(:body).returns('Test Body')
         PartyFoul::IssueRenderers::Rails.any_instance.stubs(:comment).returns('Test Comment')
-        PartyFoul.github.expects(:search_issues).with('test_fingerprint', repo: 'test_owner/test_repo', state: 'open').returns([])
-        PartyFoul.github.expects(:search_issues).with('test_fingerprint', repo: 'test_owner/test_repo', state: 'closed').returns([])
+        PartyFoul.github.expects(:search_issues).with('test_fingerprint repo:test_owner/test_repo state:open').returns(no_search_results)
+        PartyFoul.github.expects(:search_issues).with('test_fingerprint repo:test_owner/test_repo state:closed').returns(no_search_results)
         PartyFoul.github.expects(:create_issue).with('test_owner/test_repo', 'Test Title', 'Test Body', :labels => ['bug', 'custom', 'label']).returns( { number: 1 } )
         PartyFoul.github.expects(:references).with('test_owner/test_repo', 'heads/deploy').returns( sawyer_resource({object: {sha: 'abcdefg1234567890'}}) )
         PartyFoul.github.expects(:add_comment).with('test_owner/test_repo', 1, 'Test Comment')
@@ -59,8 +59,8 @@ describe 'Party Foul Exception Handler' do
         end
         PartyFoul::IssueRenderers::Rails.any_instance.stubs(:body).returns('Test Body')
         PartyFoul::IssueRenderers::Rails.any_instance.stubs(:comment).returns('Test Comment')
-        PartyFoul.github.expects(:search_issues).with('test_fingerprint', repo: 'test_owner/test_repo', state: 'open').returns([])
-        PartyFoul.github.expects(:search_issues).with('test_fingerprint', repo: 'test_owner/test_repo', state: 'closed').returns([])
+        PartyFoul.github.expects(:search_issues).with('test_fingerprint repo:test_owner/test_repo state:open').returns(no_search_results)
+        PartyFoul.github.expects(:search_issues).with('test_fingerprint repo:test_owner/test_repo state:closed').returns(no_search_results)
         PartyFoul.github.expects(:references).with('test_owner/test_repo', 'heads/deploy').returns( sawyer_resource({object: {sha: 'abcdefg1234567890'}}) )
         PartyFoul.github.expects(:add_comment).with('test_owner/test_repo', 1, 'Test Comment')
       end
@@ -93,8 +93,8 @@ describe 'Party Foul Exception Handler' do
 
     context 'and open' do
       before do
-        PartyFoul.github.expects(:search_issues).with('test_fingerprint', repo: 'test_owner/test_repo', state: 'open').returns(
-          [sawyer_resource({title: 'Test Title', body: 'Test Body', state: 'open', number: 1})] )
+        PartyFoul.github.expects(:search_issues).with('test_fingerprint repo:test_owner/test_repo state:open').returns(
+          sawyer_resource({total_count: 1, incomplete_results: false, items:[{title: 'Test Title', body: 'Test Body', state: 'open', number: 1}]}) )
         PartyFoul.github.expects(:update_issue).with('test_owner/test_repo', 1, 'Test Title', 'New Body', state: 'open')
         PartyFoul.github.expects(:references).with('test_owner/test_repo', 'heads/deploy').returns(
           sawyer_resource({object: {sha: 'abcdefg1234567890'}}) )
@@ -117,9 +117,9 @@ describe 'Party Foul Exception Handler' do
 
     context 'and closed' do
       it 'will update the count on the body and re-open the issue' do
-        PartyFoul.github.expects(:search_issues).with('test_fingerprint', repo: 'test_owner/test_repo', state: 'open').returns([])
-        PartyFoul.github.expects(:search_issues).with('test_fingerprint', repo: 'test_owner/test_repo', state: 'closed').returns(
-          [sawyer_resource({title: 'Test Title', body: 'Test Body', state: 'closed', number: 1, labels: ['staging']})] )
+        PartyFoul.github.expects(:search_issues).with('test_fingerprint repo:test_owner/test_repo state:open').returns(no_search_results)
+        PartyFoul.github.expects(:search_issues).with('test_fingerprint repo:test_owner/test_repo state:closed').returns(
+          sawyer_resource({total_count: 1, incomplete_results: false, items:[{title: 'Test Title', body: 'Test Body', state: 'closed', number: 1, labels: ['staging']}]}) )
         PartyFoul.github.expects(:update_issue).with('test_owner/test_repo', 1, 'Test Title', 'New Body', state: 'open', labels: ['bug', 'regression', 'staging'])
         PartyFoul.github.expects(:add_comment).with('test_owner/test_repo', 1, 'Test Comment')
         PartyFoul.github.expects(:references).with('test_owner/test_repo', 'heads/deploy').returns(sawyer_resource({object: {sha: 'abcdefg1234567890'}}))
@@ -131,9 +131,9 @@ describe 'Party Foul Exception Handler' do
   context 'when issue is marked as "wontfix"' do
     it 'does nothing' do
       PartyFoul::IssueRenderers::Rails.any_instance.stubs(:body).returns('Test Body')
-      PartyFoul.github.expects(:search_issues).with('test_fingerprint', repo: 'test_owner/test_repo', state: 'open').returns([])
-      PartyFoul.github.expects(:search_issues).with('test_fingerprint', repo: 'test_owner/test_repo', state: 'closed').returns(
-        [sawyer_resource({title: 'Test Title', body: 'Test Body', state: 'closed', number: 1, labels: ['wontfix']})] )
+      PartyFoul.github.expects(:search_issues).with('test_fingerprint repo:test_owner/test_repo state:open').returns(no_search_results)
+      PartyFoul.github.expects(:search_issues).with('test_fingerprint repo:test_owner/test_repo state:closed').returns(
+        sawyer_resource({total_count: 1, incomplete_results: false, items:[{title: 'Test Title', body: 'Test Body', state: 'closed', number: 1, labels: ['wontfix']}]}) )
       PartyFoul.github.expects(:create_issue).never
       PartyFoul.github.expects(:update_issue).never
       PartyFoul.github.expects(:add_comment).never

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,3 +34,7 @@ def sawyer_resource(attrs)
   agent = Sawyer::Agent.new(PartyFoul.api_endpoint)
   Sawyer::Resource.new(agent, attrs)
 end
+
+def no_search_results
+  sawyer_resource(total_count: 0, incomplete_results: false, items: [])
+end


### PR DESCRIPTION
This fixes #97. Since switching to the `search_issues` method instead of the `legacy_search_issues` method, the return value is different. The non-legacy search API includes metadata keys in the response, and nests the actual search results under an `items` key, so we need to call `items.first` instead of just `first`.

Also, the repo/state options were being completely ignored, which could potentially cause 2 problems:
1. The fingerprint might be matched in someone else's repo and updated there instead (infinitely small chance, but still a chance)
2. Closed/open issues would be returned in the same result set, potentially causing a closed issue to be updated when there was an open one that should have been updated.

The `search_issues` method expects any qualifiers (e.g. repo and state) to be part of the actual query string.

Updated the tests to account for what `search_issues` actually returns.

(I couldn't get the full test suite to run, even before any of my changes -- it was locking up on the generator test -- but all of the exception_handler tests pass).
