### PR TITLE
Patch Rake::Application to handle errors with party_foul

### DIFF
--- a/lib/party_foul.rb
+++ b/lib/party_foul.rb
@@ -79,9 +79,14 @@ module PartyFoul
   #
   # @param [Block]
   def self.configure(&block)
+    require_hooks
     yield self
     self.github ||= Octokit::Client.new access_token: oauth_token, api_endpoint: api_endpoint
   end
+end
+
+def require_hooks
+  require 'party_foul/rake' if defined?(Rake)
 end
 
 require 'party_foul/exception_handler'

--- a/lib/party_foul/rake.rb
+++ b/lib/party_foul/rake.rb
@@ -1,0 +1,11 @@
+require 'rake'
+
+module Rake
+  class Application
+    alias_method :orig_display_error_message, :display_error_message
+    def display_error_message(ex)
+      PartyFoul::RacklessExceptionHandler.handle(ex, {class: @rakefile, method: @name, params: ARGV.join(' ')})
+      orig_display_error_message(ex)
+    end
+  end
+end


### PR DESCRIPTION
Handle rake task errors with party_foul.

Sample error:

![image](https://cloud.githubusercontent.com/assets/181868/2989152/342ab0a0-dc61-11e3-852a-0eaa38987eec.png)

![image](https://cloud.githubusercontent.com/assets/181868/2989158/3be9c4c0-dc61-11e3-80ba-90e1560d8b08.png)
