### PR TITLE
Add Pry as development dependency.

### DIFF
--- a/party_foul.gemspec
+++ b/party_foul.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'm'
+  s.add_development_dependency 'pry'
 end


### PR DESCRIPTION
During my endeavors on https://github.com/dockyard/party_foul/pull/105 I'm using Pry a lot to debug. 

When I go to make some coding on party_foul, I need to add pry, bundle and don't commit this.

This PR is only to use the pry as a debugger. It helps a lot :heart:
