### PR TITLE
Current code doesn't check for existance of env['action_dispatch.request.parameters']

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.5.5
  * Remove unused attr whitelisted\_rack\_variables
-
+ * check for existance of env['action_dispatch.request.parameters'] ([Bug #107]https://github.com/dockyard/party_foul/pull/107/)
+ 
 ## 1.5.4
  * Fix test hanging
  * Updated to Octokit 3.1

--- a/lib/party_foul/issue_renderers/rails.rb
+++ b/lib/party_foul/issue_renderers/rails.rb
@@ -4,7 +4,11 @@ class PartyFoul::IssueRenderers::Rails < PartyFoul::IssueRenderers::Rack
   # @return [Hash]
   def params
     parameter_filter = ActionDispatch::Http::ParameterFilter.new(env["action_dispatch.parameter_filter"])
-    parameter_filter.filter(env['action_dispatch.request.parameters'])
+    if env['action_dispatch.request.parameters']
+      return parameter_filter.filter(env['action_dispatch.request.parameters'])
+    else
+      return parameter_filter
+    end
   end
 
   # Rails session hash. Filtered parms are respected.
@@ -30,6 +34,7 @@ class PartyFoul::IssueRenderers::Rails < PartyFoul::IssueRenderers::Rack
   end
 
   def raw_title
-    %{#{env['action_controller.instance'].class}##{env['action_dispatch.request.parameters']['action']} (#{exception.class}) "#{exception.message}"}
+    parameters = env['action_dispatch.request.parameters']['action'] if env['action_dispatch.request.parameters']
+    %{#{env['action_controller.instance'].class}##{parameters} (#{exception.class}) "#{exception.message}"}
   end
 end


### PR DESCRIPTION
issue_renderers/rails.rb doesn't check if env['action_dispatch.request.parameters'] is not nil. This can lead to an exception being raised. The change below fixes this.

I don't yet know how to test this edge case.
Any pointers and I'll gladly add a test case.
