### PR TITLE
Add '[EMPTY] message for empty session

### DIFF
--- a/lib/party_foul/issue_renderers/base.rb
+++ b/lib/party_foul/issue_renderers/base.rb
@@ -129,7 +129,11 @@ BODY
     hash.inject('') do |rows, row|
       key, value = row
       if row[1].kind_of?(Hash)
-        value = build_table_from_hash(row[1])
+        value = if row[1].empty?
+          "[EMPTY]"
+        else
+         build_table_from_hash(row[1])
+       end
       else
         value = CGI.escapeHTML(value.to_s)
       end

--- a/test/party_foul/issue_renderers/base_test.rb
+++ b/test/party_foul/issue_renderers/base_test.rb
@@ -75,8 +75,8 @@ Fingerprint: `abcdefg1234567890`
   describe '#build_table_from_hash' do
     it 'builds an HTML table from a hash' do
       rendered_issue = PartyFoul::IssueRenderers::Base.new(nil, nil)
-      hash = { 'Value 1' => 'abc', 'Value 2' => { 'Value A' => 123, 'Value B' => 456 } }
-      expected = '<table><tr><th>Value 1</th><td>abc</td></tr><tr><th>Value 2</th><td><table><tr><th>Value A</th><td>123</td></tr><tr><th>Value B</th><td>456</td></tr></table></td></tr></table>'
+      hash = { 'Value 1' => 'abc', 'Value 2' => { 'Value A' => 123, 'Value B' => 456, "Empty Hash" => { } } }
+      expected = '<table><tr><th>Value 1</th><td>abc</td></tr><tr><th>Value 2</th><td><table><tr><th>Value A</th><td>123</td></tr><tr><th>Value B</th><td>456</td></tr><tr><th>Empty Hash</th><td>[EMPTY]</td></tr></table></td></tr></table>'
       rendered_issue.build_table_from_hash(hash).must_equal expected
     end
 

--- a/test/party_foul/issue_renderers/rack_test.rb
+++ b/test/party_foul/issue_renderers/rack_test.rb
@@ -54,10 +54,15 @@ describe 'Rack Issue Renderer' do
   end  
   
   describe '#session' do
-    it 'returns the session' do
+    it 'returns the session when it has value' do
       issue_renderer = PartyFoul::IssueRenderers::Rack.new(nil, { 'rack.session' => 'abc:123' })
       issue_renderer.session.must_equal 'abc:123'
-    end    
+    end
+
+    it 'returns empty hash when it is empty' do
+      issue_renderer = PartyFoul::IssueRenderers::Rack.new(nil, {})
+      issue_renderer.session.must_equal Hash.new
+    end
   end
   
   describe '#http_headers' do


### PR DESCRIPTION
Adds an ['EMPTY'] message in cases that the Hash params is empty. It will work every 'Hash' case and not only for session. It closes #84 
