### PR TITLE
suport for ActionDispatch::Request::Session as session object

### DIFF
--- a/lib/party_foul/issue_renderers/rails.rb
+++ b/lib/party_foul/issue_renderers/rails.rb
@@ -12,7 +12,14 @@ class PartyFoul::IssueRenderers::Rails < PartyFoul::IssueRenderers::Rack
   # @return [Hash]
   def session
     parameter_filter = ActionDispatch::Http::ParameterFilter.new(env['action_dispatch.parameter_filter'])
-    parameter_filter.filter(env['rack.session'] || { } )
+
+    env_session = begin
+      env['rack.session'].to_hash
+    rescue NoMethodError
+      env['rack.session'] || { }
+    end
+
+    parameter_filter.filter(env_session)
   end
 
   # The timestamp when the exception occurred. Will use Time.current when available to record

--- a/test/party_foul/issue_renderers/rails_test.rb
+++ b/test/party_foul/issue_renderers/rails_test.rb
@@ -1,5 +1,12 @@
 require 'test_helper'
 
+# dummy ActionDispatch::Request::Session representation
+class ActionDispatchRequestSessionDummy
+   def to_hash
+    { 'status' => 'ok', 'password' => 'test' }
+  end
+end
+
 describe 'Rails Issue Renderer' do
   describe '#params' do
     before do
@@ -44,7 +51,18 @@ describe 'Rails Issue Renderer' do
       end
     end
 
+    context 'session object is Rails 4 session object' do
+      let(:params) do
+        {'action_dispatch.parameter_filter' => ['password'],
+         'rack.session' => ActionDispatchRequestSessionDummy.new ,
+         'QUERY_STRING' => { 'status' => 'fail' } }
+      end
 
+      it 'returns ok' do
+        @rendered_issue.session['status'].must_equal 'ok'
+        @rendered_issue.session['password'].must_equal '[FILTERED]'
+      end
+    end
   end
 
   describe '#raw_title' do


### PR DESCRIPTION
in Rails 4 `env['rack.session']` is `ActionDispatch::Request::Session` object  => doesn't respond to `#each` 2

```
   13: def session
    14:   parameter_filter = ActionDispatch::Http::ParameterFilter.new(env['action_dispatch.parameter_filter'])
    15: 
 => 16:   binding.pry
    17: 
    18:   env_session = begin
    19:     env['rack.session'].to_hash
    20:   rescue NoMethodError
    21:     env['rack.session'] || { }
    22:   end
    23: 
    24:   parameter_filter.filter(env_session)
    25: end

[4] pry(#<PartyFoul::IssueRenderers::Rails>)> env['rack.session'].respond_to?(:each)
=> false
[5] pry(#<PartyFoul::IssueRenderers::Rails>)> env['rack.session'].class
=> ActionDispatch::Request::Session

# so :

[6] pry(#<PartyFoul::IssueRenderers::Rails>)> parameter_filter.filter(env['rack.session'])
NoMethodError: undefined method `each' for #<ActionDispatch::Request::Session:0x000000023718e0>
from /home/tomi/.rvm/gems/ruby-2.1.2@validations/gems/actionpack-4.0.9/lib/action_dispatch/http/parameter_filter.rb:51:in `

# but

[7] pry(#<PartyFoul::IssueRenderers::Rails>)> parameter_filter.filter(env['rack.session'].to_hash)
=> {"session_id"=>"df7cf659a9c513ed84a496b747132319 ..... 

```
