### PR TITLE
Prevent exceptions just in case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ test/dummy/config/initializers/_environment.rb
 doc/*
 test/tmp/*
 *.swp
+.tags*

--- a/lib/party_foul/issue_renderers/rails.rb
+++ b/lib/party_foul/issue_renderers/rails.rb
@@ -4,7 +4,7 @@ class PartyFoul::IssueRenderers::Rails < PartyFoul::IssueRenderers::Rack
   # @return [Hash]
   def params
     parameter_filter = ActionDispatch::Http::ParameterFilter.new(env["action_dispatch.parameter_filter"])
-    parameter_filter.filter(env['action_dispatch.request.parameters'])
+    parameter_filter.filter(env['action_dispatch.request.parameters'] || {})
   end
 
   # Rails session hash. Filtered parms are respected.

--- a/lib/party_foul/issue_renderers/rails.rb
+++ b/lib/party_foul/issue_renderers/rails.rb
@@ -30,6 +30,6 @@ class PartyFoul::IssueRenderers::Rails < PartyFoul::IssueRenderers::Rack
   end
 
   def raw_title
-    %{#{env['action_controller.instance'].class}##{env['action_dispatch.request.parameters']['action']} (#{exception.class}) "#{exception.message}"}
+    %{#{env['action_controller.instance'].class}##{(env['action_dispatch.request.parameters'] || {})['action']} (#{exception.class}) "#{exception.message}"}
   end
 end

--- a/test/party_foul/issue_renderers/rails_test.rb
+++ b/test/party_foul/issue_renderers/rails_test.rb
@@ -2,13 +2,22 @@ require 'test_helper'
 
 describe 'Rails Issue Renderer' do
   describe '#params' do
+    let(:request_parameters) { { 'status' => 'ok', 'password' => 'test' } }
     before do
-      @rendered_issue = PartyFoul::IssueRenderers::Rails.new(nil, {'action_dispatch.parameter_filter' => ['password'], 'action_dispatch.request.parameters' => { 'status' => 'ok', 'password' => 'test' }, 'QUERY_STRING' => { 'status' => 'fail' } })
+      @rendered_issue = PartyFoul::IssueRenderers::Rails.new(nil, {'action_dispatch.parameter_filter' => ['password'], 'action_dispatch.request.parameters' => request_parameters, 'QUERY_STRING' => { 'status' => 'fail' } })
     end
 
     it 'returns ok' do
       @rendered_issue.params['status'].must_equal 'ok'
       @rendered_issue.params['password'].must_equal '[FILTERED]'
+    end
+
+    context 'without request parameters' do
+      let(:request_parameters) { nil }
+
+      it 'returns empty hash' do
+        @rendered_issue.params.must_equal({})
+      end
     end
   end
 

--- a/test/party_foul/issue_renderers/rails_test.rb
+++ b/test/party_foul/issue_renderers/rails_test.rb
@@ -48,12 +48,13 @@ describe 'Rails Issue Renderer' do
   end
 
   describe '#raw_title' do
+    let(:request_parameters) { { 'controller' => 'landing', 'action' => 'index' } }
     before do
       @exception = Exception.new('message')
       controller_instance = mock('Controller')
       controller_instance.stubs(:class).returns('LandingController')
       env = {
-        'action_dispatch.request.parameters' => { 'controller' => 'landing', 'action' => 'index' },
+        'action_dispatch.request.parameters' => request_parameters,
         'action_controller.instance' => controller_instance
       }
       @rendered_issue = PartyFoul::IssueRenderers::Rails.new(@exception, env)
@@ -61,6 +62,14 @@ describe 'Rails Issue Renderer' do
 
     it 'constructs the title with the controller and action' do
       @rendered_issue.send(:raw_title).must_equal %{LandingController#index (Exception) "message"}
+    end
+
+    context 'without request parameters' do
+      let(:request_parameters) { nil }
+
+      it 'leaves action blank' do
+        @rendered_issue.send(:raw_title).must_equal %{LandingController# (Exception) "message"}
+      end
     end
   end
 end


### PR DESCRIPTION
This change makes PartyFoul a tiny bit more resilient, and will hopefully save some people time spent debugging.

Over time, we added middleware (unintentionally after PartyFoul) which had a bug that intermittently caused exceptions.  In this type of situation, PartyFoul's own exception obscures the original exception.

As a bonus, this change would allow PartyFoul to report exceptions in middleware (at least in the case described; I'm sure there are other reasons why it must be the last middleware).

Related to #107 and #111.