### PR TITLE
Kill trailing space in template and Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ PartyFoul.configure do |config|
   # The branch for your deployed code
   # config.branch               = 'master'
 
+  # Additional labels to add to issues created
+  # config.additional_labels    = ['production']
+  # or
+  # config.additional_labels    = Proc.new do |exception, env|
+  #   []
+  # end
+
+  # Limit the number of comments per issue
+  # config.comment_limit        = 10
+
   # Setting your title prefix can help with
   # distinguising the issue between environments
   # config.title_prefix         = Rails.env

--- a/lib/generators/party_foul/templates/party_foul.rb
+++ b/lib/generators/party_foul/templates/party_foul.rb
@@ -6,7 +6,7 @@ PartyFoul.configure do |config|
   # The OAuth token for the account that is opening the issues on GitHub
   config.oauth_token            = '<%= @oauth_token %>'
 
-  # The API api_endpoint for GitHub. Unless you are hosting a private
+  # The API endpoint for GitHub. Unless you are hosting a private
   # instance of Enterprise GitHub you do not need to include this
   config.api_endpoint           = '<%= @api_endpoint %>'
 
@@ -33,7 +33,7 @@ PartyFoul.configure do |config|
   # Limit the number of comments per issue
   # config.comment_limit        = 10
 
-  # Setting your title prefix can help with 
+  # Setting your title prefix can help with
   # distinguising the issue between environments
   # config.title_prefix         = Rails.env
 end


### PR DESCRIPTION
The generator generates comments too. Reflect that in README's template.