### PR TITLE
Upgrade/octokit to v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.5.6
+ * Upgrade Octokit to 4.x
+
 ## 1.5.5
  * Remove unused attr whitelisted\_rack\_variables
  * env['action_dispatch.request.parameters'] not present when file is
@@ -17,7 +20,7 @@
    opposed to pessimistic patch version - Rodrigo Pinto
 
 ## 1.5.1
- 
+
  * Uses `env['action_dispatch.request.parameters']` instead of
    `path_parameters` in rails renderer to fix missing params issue
    ([Bug #82](https://github.com/dockyard/party_foul/issues/82)) - Dan McClain

--- a/lib/party_foul/version.rb
+++ b/lib/party_foul/version.rb
@@ -1,3 +1,3 @@
 module PartyFoul
-  VERSION = '1.5.5'
+  VERSION = '1.5.6'.freeze
 end

--- a/party_foul.gemspec
+++ b/party_foul.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*'] + ['Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'octokit', '~> 3.1'
+  s.add_dependency 'octokit', '~> 4.2'
 
   s.add_development_dependency 'actionpack', '~> 4.0'
   s.add_development_dependency 'activesupport', '~> 4.0'


### PR DESCRIPTION
Places use Octokit:

- [x] https://github.com/dockyard/party_foul/blob/master/lib/party_foul.rb#L83
- [x] https://github.com/dockyard/party_foul/blob/master/lib/generators/party_foul/install_generator.rb#L17-L18
- [x] CHANGELOG + v1.5.6 :heart_eyes: 

Tested this branch in one of my project, and it works! Octokit rocks : )