### PR TITLE
GitHub API issue title length is 256 chars

### DIFF
--- a/lib/party_foul/issue_renderers/base.rb
+++ b/lib/party_foul/issue_renderers/base.rb
@@ -16,11 +16,13 @@ class PartyFoul::IssueRenderers::Base
   #
   # @return [String]
   def title
-    if PartyFoul.title_prefix
+    _title = if PartyFoul.title_prefix
       "[#{PartyFoul.title_prefix}] #{masked_title}"
     else
       masked_title
     end
+
+    _title[0..255]
   end
 
   # Renders the issue body

--- a/test/party_foul/issue_renderers/base_test.rb
+++ b/test/party_foul/issue_renderers/base_test.rb
@@ -143,6 +143,20 @@ Fingerprint: `abcdefg1234567890`
         fingerprint.wont_equal rendered_issue.fingerprint
       end
     end
+
+    context 'title length limit' do
+      before do
+        PartyFoul.configure do |config|
+          config.title_prefix = 'PRODUCTION'
+        end
+      end
+
+      it 'at most 256 chars' do
+        rendered_issue = PartyFoul::IssueRenderers::Base.new(nil, nil)
+        rendered_issue.stubs(:raw_title).returns('F'*300)
+        rendered_issue.title.size.must_equal 256
+      end
+    end
   end
 
   describe '#stack_trace' do


### PR DESCRIPTION
This Pull Request limits the issue title to 256 chars.

--

Found an error from my application:

```
Octokit::UnprocessableEntity (POST https://api.github.com/repos/jollygoodcode/rebasenow/issues: 422 - Validation Failed
Error summary:
  resource: Issue
  code: custom
  field: title
  message: title is too long // See: https://developer.github.com/v3/issues/#create-an-issue):
  vendor/bundle/ruby/2.3.0/gems/octokit-4.2.0/lib/octokit/response/raise_error.rb:16:in `on_complete'
  vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/response.rb:9:in `block in call'
  vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/response.rb:57:in `on_complete'
  vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/response.rb:8:in `call'
  vendor/bundle/ruby/2.3.0/gems/octokit-4.2.0/lib/octokit/middleware/follow_redirects.rb:73:in `perform_with_redirection'
  vendor/bundle/ruby/2.3.0/gems/octokit-4.2.0/lib/octokit/middleware/follow_redirects.rb:61:in `call'
  vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/rack_builder.rb:139:in `build_response'
  vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/connection.rb:377:in `run_request'
  vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/connection.rb:177:in `post'
  vendor/bundle/ruby/2.3.0/gems/sawyer-0.6.0/lib/sawyer/agent.rb:94:in `call'
  vendor/bundle/ruby/2.3.0/gems/octokit-4.2.0/lib/octokit/connection.rb:154:in `request'
  vendor/bundle/ruby/2.3.0/gems/octokit-4.2.0/lib/octokit/connection.rb:28:in `post'
  vendor/bundle/ruby/2.3.0/gems/octokit-4.2.0/lib/octokit/client/issues.rb:101:in `create_issue'
  vendor/bundle/ruby/2.3.0/bundler/gems/party_foul-aaa5efc10549/lib/party_foul/exception_handler.rb:45:in `create_issue'
  vendor/bundle/ruby/2.3.0/bundler/gems/party_foul-aaa5efc10549/lib/party_foul/exception_handler.rb:33:in `run'
  vendor/bundle/ruby/2.3.0/bundler/gems/party_foul-aaa5efc10549/lib/party_foul/processors/sync.rb:9:in `handle'
  vendor/bundle/ruby/2.3.0/bundler/gems/party_foul-aaa5efc10549/lib/party_foul/exception_handler.rb:10:in `handle'
  vendor/bundle/ruby/2.3.0/bundler/gems/party_foul-aaa5efc10549/lib/party_foul/middleware.rb:11:in `rescue in call'
  vendor/bundle/ruby/2.3.0/bundler/gems/party_foul-aaa5efc10549/lib/party_foul/middleware.rb:8:in `call'
```

256 is by trial and error. The [offical GitHub API doc](https://developer.github.com/v3/issues/#create-an-issue) does not specify the length of title.
