### PR TITLE
Use to_hash to eager load Rails session before read

### DIFF
--- a/lib/party_foul/issue_renderers/rails.rb
+++ b/lib/party_foul/issue_renderers/rails.rb
@@ -12,7 +12,8 @@ class PartyFoul::IssueRenderers::Rails < PartyFoul::IssueRenderers::Rack
   # @return [Hash]
   def session
     parameter_filter = ActionDispatch::Http::ParameterFilter.new(env['action_dispatch.parameter_filter'])
-    parameter_filter.filter(env['rack.session'] || { } )
+    rails_session = (env['rack.session'] || {}).to_hash
+    parameter_filter.filter(rails_session)
   end
 
   # The timestamp when the exception occurred. Will use Time.current when available to record


### PR DESCRIPTION
In Rails 4, `env['rack.session']` contains `ActionDispatch::Request::Session` object, where session data is not loaded until being accessed by controllers [1].

To load session data properly for reading, we can call `Session#to_hash` [2].

[1] https://github.com/rails/rails/issues/10813#issuecomment-41490926
[2] https://github.com/rails/rails/blob/v4.0.3/actionpack/lib/action_dispatch/request/session.rb#L115

This has caused our production environment throwing errors similar to this:

```
NoMethodError: undefined method `each' for #<ActionDispatch::Request::Session:0x7f92db05ae18 not yet loaded>
    /Users/huiming/.gem/ruby/2.3.0/gems/actionpack-4.0.13/lib/action_dispatch/http/parameter_filter.rb:51:in `call'
    /Users/huiming/.gem/ruby/2.3.0/gems/actionpack-4.0.13/lib/action_dispatch/http/parameter_filter.rb:11:in `filter'
    /Users/huiming/work/party_foul/lib/party_foul/issue_renderers/rails.rb:16:in `session'
```
