### PR TITLE
Add blacklist exceptions support to RacklessExceptionHandler

### DIFF
--- a/lib/party_foul/middleware.rb
+++ b/lib/party_foul/middleware.rb
@@ -7,26 +7,8 @@ module PartyFoul
     def call(env)
       @app.call(env)
     rescue Exception => captured_exception
-      if allow_handling?(captured_exception)
-        PartyFoul::ExceptionHandler.handle(captured_exception, env)
-      end
+      PartyFoul::ExceptionHandler.handle(captured_exception, env)
       raise captured_exception
-    end
-
-    private
-
-    def allow_handling?(captured_exception)
-      !PartyFoul.blacklisted_exceptions.find do |blacklisted_exception|
-        names = blacklisted_exception.split('::')
-        names.shift if names.empty? || names.first.empty?
-
-        constant = Object
-        names.each do |name|
-          constant = constant.const_defined?(name) ? constant.const_get(name) : constant.const_missing(name)
-        end
-
-        constant === captured_exception
-      end
     end
   end
 end

--- a/lib/party_foul/rackless_exception_handler.rb
+++ b/lib/party_foul/rackless_exception_handler.rb
@@ -5,7 +5,9 @@ class PartyFoul::RacklessExceptionHandler < PartyFoul::ExceptionHandler
   #
   # @param [Exception, Hash]
   def self.handle(exception, env)
-    self.new(exception, clean_env(env)).run
+    if allow_handling?(exception)
+      self.new(exception, clean_env(env)).run
+    end
   end
 
   # Uses the Rackless IssueRenderer for a rackless environment

--- a/test/party_foul/rackless_exception_handler_test.rb
+++ b/test/party_foul/rackless_exception_handler_test.rb
@@ -20,7 +20,19 @@ describe 'Party Foul Rackless Exception Handler' do
       expected_exception_handler = PartyFoul::RacklessExceptionHandler.new(nil, params)
       expected_exception_handler.expects(:run)
       PartyFoul::RacklessExceptionHandler.expects(:new).with(nil, params).returns(expected_exception_handler)
-      PartyFoul::RacklessExceptionHandler.handle(nil, params)      
+      PartyFoul::RacklessExceptionHandler.handle(nil, params)
+    end
+
+    context 'filtering based upon exception' do
+      before do
+        PartyFoul.blacklisted_exceptions = ['StandardError']
+      end
+
+      it 'does not handle exception' do
+        PartyFoul::RacklessExceptionHandler.expects(:new).never
+
+        PartyFoul::RacklessExceptionHandler.handle StandardError.new, {}
+      end
     end
   end
 


### PR DESCRIPTION
Hello there,

This Pull Request adds blacklist exceptions support to RacklessExceptionHandler.

The use case is:

I use party_foul with delayed_job:

``` ruby
Delayed::Worker.lifecycle.around(:invoke_job) do |job, *args, &block|
  begin
    block.call(job, *args)
  rescue Exception => exception
    PartyFoul::RacklessExceptionHandler.handle(exception, ...)
    raise 
  end
end
```

I have some non-critical exceptions that do not need party_foul to report to GitHub. 

So I add blacklist exceptions functionality to RacklessExceptionHandler.

What do you think?

Thank you.
