### PR TITLE
Updated README for generating oauth via curl as note is required field.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ or generate an OAuth token via the
 [OAuth Authorizations API](http://developer.github.com/v3/oauth/#oauth-authorizations-api) with cURL:
 
 ```bash
-curl -u <github_login> -i -d "{ \"scopes\": [\"repo\"] }" \
+curl -u <github_login> -i -d "{ \"scopes\": [\"repo\"], \"note\":[\"Test\"] }" \
 https://api.github.com/authorizations
 ```
 


### PR DESCRIPTION
Previous curl request gives:
```JSON
{
  "message": "Validation Failed",
  "errors": [
    {
      "resource": "OauthAccess",
      "code": "missing_field",
      "field": "description"
    }
  ],
  "documentation_url": "https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization"
}
```

Updated curl with [Note field which is a required field](https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization).