### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,13 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 2.0.0
-  - 2.1.8
-  - 2.2.4
-  - 2.3.0
-  - 1.9.3
+  - 2.4.0
+  - 2.3.3
+  - 2.2.6
+  - 2.1
   - ruby-head
 matrix:
   allow_failures:
-    - rvm: 1.9.3
     - rvm: ruby-head
 notifications:
   email:

--- a/lib/party_foul.rb
+++ b/lib/party_foul.rb
@@ -2,7 +2,8 @@ require 'octokit'
 
 module PartyFoul
   class << self
-    attr_accessor :github, :oauth_token, :api_endpoint, :owner, :repo, :blacklisted_exceptions, :processor, :web_url, :branch, :additional_labels, :comment_limit, :title_prefix
+    attr_accessor :github, :oauth_token, :owner, :repo, :additional_labels, :comment_limit, :title_prefix
+    attr_writer :branch, :web_url, :api_endpoint, :processor, :blacklisted_exceptions
   end
 
   # The git branch that is used for linking in the stack trace

--- a/lib/party_foul.rb
+++ b/lib/party_foul.rb
@@ -78,9 +78,9 @@ module PartyFoul
   # Will also setup for GitHub api connections
   #
   # @param [Block]
-  def self.configure(&block)
+  def self.configure
     yield self
-    self.github ||= Octokit::Client.new access_token: oauth_token, api_endpoint: api_endpoint
+    self.github = Octokit::Client.new access_token: oauth_token, api_endpoint: api_endpoint
   end
 end
 

--- a/lib/party_foul/issue_renderers/base.rb
+++ b/lib/party_foul/issue_renderers/base.rb
@@ -2,7 +2,6 @@ require 'cgi'
 
 class PartyFoul::IssueRenderers::Base
   attr_accessor :exception, :env, :sha
-  attr_reader :body
 
   # A new renderer instance for GitHub issues
   #

--- a/party_foul.gemspec
+++ b/party_foul.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = 'Auto-submit Rails exceptions as new issues on GitHub'
   s.license     = 'MIT'
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.1.0'
 
   s.files = Dir['{app,config,db,lib}/**/*'] + ['Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']

--- a/party_foul.gemspec
+++ b/party_foul.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'actionpack', '~> 4.0'
   s.add_development_dependency 'activesupport', '~> 4.0'
   s.add_development_dependency 'railties', '~> 4.0'
-  s.add_development_dependency 'minitest', '~> 4.7'
+  s.add_development_dependency 'minitest', '~> 5.8'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'mocha'

--- a/test/party_foul/exception_handler_test.rb
+++ b/test/party_foul/exception_handler_test.rb
@@ -106,9 +106,7 @@ describe 'Party Foul Exception Handler' do
       end
 
       it "doesn't post a comment if the limit has been met" do
-        PartyFoul.configure do |config|
-          config.comment_limit = 10
-        end
+        PartyFoul.comment_limit = 10
         PartyFoul::ExceptionHandler.any_instance.expects(:occurrence_count).returns(10)
         PartyFoul.github.expects(:add_comment).never
         PartyFoul::ExceptionHandler.new(nil, {}).run

--- a/test/party_foul/issue_renderers/base_test.rb
+++ b/test/party_foul/issue_renderers/base_test.rb
@@ -106,16 +106,24 @@ Fingerprint: `abcdefg1234567890`
   end
 
   describe '#title' do
-    it 'masks the object ids in the raw_title' do
-      rendered_issue = PartyFoul::IssueRenderers::Base.new(nil, nil)
-      rendered_issue.stubs(:raw_title).returns('Error for #<ClassName:0xabcdefg1234567>')
-      rendered_issue.title.must_equal 'Error for #<ClassName:0xXXXXXX>'
-    end
+    context 'when no title prefix is configured' do
+      before do
+        PartyFoul.configure do |config|
+          config.title_prefix = nil
+        end
+      end
 
-    it 'masks the extended object ids in the raw_title' do
-      rendered_issue = PartyFoul::IssueRenderers::Base.new(nil, nil)
-      rendered_issue.stubs(:raw_title).returns('Error for #<#<ClassName:0x007fbddbdcd340>:0x007fbddf6be0a0>')
-      rendered_issue.title.must_equal 'Error for #<#<ClassName:0xXXXXXX>:0xXXXXXX>'
+      it 'masks the object ids in the raw_title' do
+        rendered_issue = PartyFoul::IssueRenderers::Base.new(nil, nil)
+        rendered_issue.stubs(:raw_title).returns('Error for #<ClassName:0xabcdefg1234567>')
+        rendered_issue.title.must_equal 'Error for #<ClassName:0xXXXXXX>'
+      end
+
+      it 'masks the extended object ids in the raw_title' do
+        rendered_issue = PartyFoul::IssueRenderers::Base.new(nil, nil)
+        rendered_issue.stubs(:raw_title).returns('Error for #<#<ClassName:0x007fbddbdcd340>:0x007fbddf6be0a0>')
+        rendered_issue.title.must_equal 'Error for #<#<ClassName:0xXXXXXX>:0xXXXXXX>'
+      end
     end
 
     context 'when a custom title prefix is configured' do

--- a/test/party_foul/issue_renderers/base_test.rb
+++ b/test/party_foul/issue_renderers/base_test.rb
@@ -186,6 +186,7 @@ Fingerprint: `abcdefg1234567890`
     end
 
     it 'formats the stack trace with link to shortened application path' do
+      clean_up_party
       exception = mock do
         stubs backtrace: ['/path/to/app/lib/some/file.rb:123 in `method`']
       end

--- a/test/party_foul/issue_renderers/rails_test.rb
+++ b/test/party_foul/issue_renderers/rails_test.rb
@@ -27,7 +27,6 @@ describe 'Rails Issue Renderer' do
       Time.stubs(:current).returns(Time.new(1970, 1, 1, 0, 0, 1, '-05:00'))
       current_as_string = Time.current.strftime('%B %d, %Y %H:%M:%S %z')
       rendered_issue = PartyFoul::IssueRenderers::Rails.new(nil, nil)
-      expected = rendered_issue.occurred_at
       rendered_issue.occurred_at.must_equal current_as_string
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,8 +11,10 @@ rescue LoadError
 end
 require 'rack/test'
 require 'mocha/setup'
+require 'active_support'
 require 'party_foul'
 
+ActiveSupport.test_order = :random
 
 class MiniTest::Spec
   class << self


### PR DESCRIPTION
* Require ruby 2.1+ (drop 1.9.3, 2.0.0)
* Update travis matrix
* Fix configure bug with Octokit client
* Fix ruby warnings
* Update development to minitest 5
* Set test order to suppress warnings
* Set title_prefix in tests so tests work when run in random order
