### PR TITLE
Bugfix/132 dont assume that exceptions have a backtrace

### DIFF
--- a/lib/party_foul/issue_renderers/base.rb
+++ b/lib/party_foul/issue_renderers/base.rb
@@ -57,7 +57,7 @@ BODY
   #
   # @return [String]
   def stack_trace
-    exception.backtrace.map do |line|
+    (exception.backtrace || []).map do |line|
       if from_bundler?(line)
         format_line(line)
       elsif (matches = extract_file_name_and_line_number(line))


### PR DESCRIPTION
Fixes #132 